### PR TITLE
search plugin header part done

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -3,7 +3,7 @@
 -------------------------------------------*/
 
 body {
-  background-color: #FFFBF7;
+  background-color: #fffbf7;
 }
 
 /*-------------------------------------------
@@ -227,12 +227,12 @@ header {
   padding-left: 25px;
 }
 
-.global-navigation__list>li {
+.global-navigation__list > li {
   padding-bottom: 20px;
   border-bottom: 2px solid #e7e9ee;
 }
 
-.global-navigation__list>li+li {
+.global-navigation__list > li + li {
   margin-top: 20px;
 }
 
@@ -303,7 +303,7 @@ header {
   font-size: 0.75rem;
 }
 
-.accordion__list li+li {
+.accordion__list li + li {
   margin-top: 21px;
 }
 
@@ -514,7 +514,8 @@ footer {
   }
 }
 
-@media (max-width: 480px) {}
+@media (max-width: 480px) {
+}
 
 /*-------------------------------------------
 サイドナビ全体
@@ -546,67 +547,66 @@ footer {
 
 /* 1つめの背骨 */
 .side-nav .file-tab:nth-child(1)::before {
-  background: #4A2B00;
+  background: #4a2b00;
   top: -10px;
   right: 0px;
 }
 
 /* 2つめの背骨 */
 .side-nav .file-tab:nth-child(2)::before {
-  background: #67420F;
+  background: #67420f;
   top: -149px;
   right: 5px;
 }
 
 /* 3つめの背骨 */
 .side-nav .file-tab:nth-child(3)::before {
-  background: #85602D;
+  background: #85602d;
   top: -267px;
   right: 10px;
 }
 
 /* タブ本体共通部分*/
-.side-nav .file-tab>a {
+.side-nav .file-tab > a {
   position: relative;
   z-index: 10;
   display: block;
   width: 30px;
   padding: 12px 6px;
-  color: #FFFBF7;
+  color: #fffbf7;
   font-weight: 500;
   text-decoration: none;
   writing-mode: vertical-rl;
   text-orientation: mixed;
-  letter-spacing: .1em;
+  letter-spacing: 0.1em;
   border-radius: 10px 0 0 10px;
   transform-origin: right center;
-  transition: transform .2s ease, filter .2s ease;
+  transition: transform 0.2s ease, filter 0.2s ease;
   border: 0px solid transparent;
   top: 50px;
 }
 
 /* ホバー */
-.side-nav .file-tab>a:hover {
+.side-nav .file-tab > a:hover {
   transform: translateX(-4px);
   filter: brightness(1.04);
 }
 
 /* 色バリエーション（任意） */
-.side-nav .file-tab:nth-child(1)>a {
-  background: #4A2B00;
+.side-nav .file-tab:nth-child(1) > a {
+  background: #4a2b00;
   margin-left: 1px;
 }
 
-.side-nav .file-tab:nth-child(2)>a {
-  background: #67420F;
+.side-nav .file-tab:nth-child(2) > a {
+  background: #67420f;
   margin-left: -3px;
 }
 
-.side-nav .file-tab:nth-child(3)>a {
-  background: #85602D;
+.side-nav .file-tab:nth-child(3) > a {
+  background: #85602d;
   margin-left: -5px;
 }
-
 
 /* 展開パネル：右のオフセットをタブ幅に合わせて調整 */
 .side-nav .index-panel {
@@ -620,20 +620,20 @@ footer {
 }
 
 .side-nav .index-panel a {
-  color: #FFFBF7;
+  color: #fffbf7;
   border: 0px solid transparent;
 }
 
 .side-nav .file-tab:nth-child(1) .index-panel {
-  background: #4A2B00;
+  background: #4a2b00;
 }
 
 .side-nav .file-tab:nth-child(2) .index-panel {
-  background: #67420F;
+  background: #67420f;
 }
 
 .side-nav .file-tab:nth-child(3) .index-panel {
-  background: #85602D;
+  background: #85602d;
 }
 
 .side-nav .file-tab:hover .index-panel,
@@ -662,9 +662,8 @@ footer {
   /* 読みやすい濃いめのブラウン */
 }
 
-
 .side-nav .searchandfilter input[type="checkbox"] {
-  accent-color: var(--color-main, #4A2B00);
+  accent-color: var(--color-main, #4a2b00);
 }
 
 /* 不要なら件数(○)を消す */
@@ -679,13 +678,13 @@ footer {
 
 /* サイドバー内の Search & Filter 共通文字色 */
 .side-nav .searchandfilter {
-  color: #FFFBF7;
+  color: #fffbf7;
   /* ← 全体の文字色（例: 明るい色に） */
 }
 
 /* チェックボックス横のラベル */
 .side-nav .searchandfilter label {
-  color: #FFFBF7;
+  color: #fffbf7;
   /* ← ラベルの文字色 */
   font-weight: 500;
   /* 太さを調整するなら */
@@ -702,8 +701,56 @@ footer {
 } */
 
 /* モバイルは非表示 */
-@media (max-width:768px) {
+@media (max-width: 768px) {
   .side-nav {
     display: none;
   }
 }
+
+/*-------------------------------------------
+ヘッダー検索フォームのライブサーチ
+-------------------------------------------*/
+#keywords-search-results {
+  display: none;
+  background: #fff;
+  border: 1px solid #ddd;
+  max-width: 350px;
+  max-height: 400px;
+  height: auto;
+  overflow-y: scroll;
+  position: absolute;
+  right: 5%;
+  top: 130px;
+  z-index: 9999;
+}
+
+#clear-button {
+  display: none;
+}
+#keywords-search-results #results-list {
+  padding: 5px 10px;
+}
+#keywords-search-results #results-list li {
+  list-style: none;
+  border-bottom: 1px solid #eee;
+  padding: 10px 0;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 10px;
+}
+#keywords-search-results #results-lis .result-text {
+  font-size: 0.75rem;
+}
+#keywords-search-results #results-list .result-img {
+  width: 100px;
+  height: auto;
+}
+#keywords-search-results #results-list .result-title {
+  font-weight: 700;
+  color: var(--color-main);
+  margin-bottom: 5px;
+}
+/* #search-results div:hover {
+  background: #f0f0f0;
+} */

--- a/css/index.css
+++ b/css/index.css
@@ -316,7 +316,6 @@ header {
 -------------------------------------------*/
 .info-top {
   margin-bottom: 3.5rem;
-  margin: 0 3%;
 }
 
 .info-underline {

--- a/functions.php
+++ b/functions.php
@@ -21,21 +21,6 @@ function add_styles()
     );
 
 
-    // index.css
-    wp_enqueue_style(
-        'index_style',
-        get_template_directory_uri() . '/css/index.css',
-        array('reset_style'),
-        '1.0'
-    );
-
-    // main.cssを最後に実行
-    wp_enqueue_style(
-        'main_style',
-        get_template_directory_uri() . '/css/main.css',
-        array('reset_style'),
-        '1.0'
-    );
 
     // detail.css
     wp_enqueue_style(
@@ -44,6 +29,32 @@ function add_styles()
         array('reset_style', 'main_style'),
         '1.0'
     );
+
+        // event.css
+        if(is_page('event')){
+            wp_enqueue_style(
+                'event_style',
+                get_template_directory_uri() . '/css/event.css',
+                array('reset_style', 'main_style'),
+                '1.0'
+            );
+        }
+        // index.css
+        wp_enqueue_style(
+            'index_style',
+            get_template_directory_uri() . '/css/index.css',
+            array('reset_style'),
+            '1.0'
+        );
+    
+        // main.cssを最後に実行
+        wp_enqueue_style(
+            'main_style',
+            get_template_directory_uri() . '/css/main.css',
+            array('reset_style'),
+            '1.0'
+        );
+    
 }
 
 add_action('wp_enqueue_scripts', 'add_scripts');
@@ -67,6 +78,15 @@ function add_scripts()
 
     // noConflict モードで jQuery を $ に割り当てない
     // wp_add_inline_script('jquery', 'jQuery.noConflict();');
+
+    // search&filterのjs
+    wp_enqueue_script(
+        'search-script',
+        get_template_directory_uri() . '/js/search.js',
+        array('jquery'),
+        '1.0',
+        true
+    );
 
     // main.jsを最後に実行
     wp_enqueue_script(

--- a/header.php
+++ b/header.php
@@ -40,7 +40,7 @@
          
         
         <!-- 検索フォーム 本番用-->
-        <form method="get" action="#" class="search_container">
+        <form method="get" action="/search-result" class="search_container">
             <input type="text" id="live-search"  size="25" placeholder="キーワード検索" />
             <button id="clear-button" type="button">×</button>
             <button id="header-keywords-submit" type="submit">

--- a/header.php
+++ b/header.php
@@ -25,17 +25,27 @@
           <ul class="nav-menu">
             <li><a href="<?php echo esc_url(home_url());?>">Home</a></li>
             <li><a href="<?php echo esc_url(home_url('/category.html'));?>">Category</a></li>
-            <li><a href="<?php echo esc_url(home_url('/event.html'));?>">Event</a></li>
+            <?php $page = get_page_by_path('event'); if ($page) :?>
+              <li><a href="<?php echo esc_url(get_permalink($page->ID)); ?>">Event</a></li>
+            <?php endif; ?>
+
+            <!-- <li><a href="<?php echo esc_url(home_url('/event.html'));?>">Event</a></li> -->
           </ul>
         </nav>
-      
-        <?php echo do_shortcode('[searchwp_form id="1"]'); ?>
 
-        <!-- 検索フォーム -->
-        <!-- <form method="get" action="#" class="search_container">
-            <input type="text" size="25" placeholder="キーワード検索" />
-            <button type="submit">
-              <svg
+
+        <!-- 検索フォーム1 search&filter　これは参考後で消す-->
+        <!-- <?php echo do_shortcode('[searchwp_form id="1"]'); ?> -->
+        <!-- <?php echo do_shortcode('[searchandfilter  fields="search,category,post_tag" headings=",Categories,Tags" types="search" post_types="post"]'); ?> -->
+         
+        
+        <!-- 検索フォーム 本番用-->
+        <form method="get" action="#" class="search_container">
+            <input type="text" id="live-search"  size="25" placeholder="キーワード検索" />
+            <button id="clear-button" type="button">×</button>
+            <button id="header-keywords-submit" type="submit">
+              検索
+              <!-- <svg
                 xmlns="http://www.w3.org/2000/svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 version="1.1"
@@ -63,9 +73,12 @@
                     d="M399.391,362.313L358,320.906c0.063-0.094,0.063-0.188,0.125-0.25c26.563-34.719,41.156-77.688,41.125-121.031   c0.047-53.281-20.703-103.438-58.469-141.156C303.109,20.766,253.063,0,199.375,0C146.172,0,96.141,20.766,58.469,58.469   C20.703,96.188-0.063,146.344,0,199.641c-0.047,53.297,20.719,103.422,58.453,141.141c37.688,37.719,87.766,58.469,141.188,58.469   h0.188c43.234,0,86.141-14.594,120.828-41.125c0.078-0.063,0.156-0.094,0.234-0.125l41.406,41.406L399.391,362.313z    M294.688,294.688c-25.391,25.344-59.125,39.344-95.078,39.406c-35.922-0.063-69.672-14.063-95.047-39.406   c-25.359-25.359-39.344-59.125-39.391-95.063c0.047-35.938,14.031-69.688,39.375-95.063c25.375-25.344,59.125-39.313,95.063-39.391   c0.016-0.016,0.031,0,0.031,0c35.922,0.078,69.672,14.047,95.047,39.391c25.344,25.359,39.328,59.125,39.391,95.094   C334.016,235.578,320.031,269.344,294.688,294.688z"
                   />
                 </g>
-              </svg>
+              </svg> -->
             </button>
-        </form> -->
+        </form>
+      </div>
+      <div id="keywords-search-results">
+
       </div>
 
 <!-- SP版　レスポンシブ　ハンバーガーメニュー -->
@@ -121,5 +134,4 @@
         </div>
       </div>
       
-
     </header>

--- a/html/index.html
+++ b/html/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="../css/main.css" />
     <link rel="stylesheet" href="../css/index.css" />
     <link rel="stylesheet" href="../css/event.css" />
-    <link rel="stylesheet" href="../css/detail.css">
+    <link rel="stylesheet" href="../css/detail.css" />
   </head>
 
   <body>
@@ -436,6 +436,7 @@
     </footer>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="../js/search.js"></script>
     <script src="../js/main.js"></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -91,42 +91,43 @@ focusTrap.addEventListener("focus", (e) => {
 });
 
 // Detail Page　コメント欄展開
-(function(){
-  const openBtn  = document.querySelector('[data-action="open-comments"]');
-  const drawer   = document.getElementById('commentDrawer');
-  const closeBtn = drawer.querySelector('.drawer-close');
+(function () {
+  const openBtn = document.querySelector('[data-action="open-comments"]');
+  const drawer = document.getElementById("commentDrawer");
+  const closeBtn = drawer.querySelector(".drawer-close");
 
-  function updateAppScale(){
+  function updateAppScale() {
     const vw = window.innerWidth;
-    const dw = drawer.getBoundingClientRect().width;  // 実サイズを取得
+    const dw = drawer.getBoundingClientRect().width; // 実サイズを取得
     let scale = (vw - dw) / vw;
 
     // 下限・上限を軽くガード（必要に応じて調整）
     scale = Math.min(1, Math.max(0.55, scale));
 
-    document.documentElement.style
-      .setProperty('--app-scale', scale);
+    document.documentElement.style.setProperty("--app-scale", scale);
   }
 
-  function openDrawer(e){
+  function openDrawer(e) {
     if (e) e.preventDefault();
-    drawer.classList.add('is-open');
-    document.body.classList.add('drawer-open');
-    updateAppScale();            // ← 開くたびに計算
+    drawer.classList.add("is-open");
+    document.body.classList.add("drawer-open");
+    updateAppScale(); // ← 開くたびに計算
   }
 
-  function closeDrawer(){
-    drawer.classList.remove('is-open');
-    document.body.classList.remove('drawer-open');
+  function closeDrawer() {
+    drawer.classList.remove("is-open");
+    document.body.classList.remove("drawer-open");
     // 元に戻すなら任意：document.documentElement.style.removeProperty('--app-scale');
   }
 
-  openBtn?.addEventListener('click', openDrawer);
-  closeBtn?.addEventListener('click', closeDrawer);
-  document.addEventListener('keydown', (e)=>{ if(e.key==='Escape') closeDrawer(); });
+  openBtn?.addEventListener("click", openDrawer);
+  closeBtn?.addEventListener("click", closeDrawer);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeDrawer();
+  });
 
   // ウィンドウリサイズ時も追従（開いている時だけ）
-  window.addEventListener('resize', () => {
-    if (document.body.classList.contains('drawer-open')) updateAppScale();
+  window.addEventListener("resize", () => {
+    if (document.body.classList.contains("drawer-open")) updateAppScale();
   });
 })();

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,160 @@
+// 2文字未満 → 予測検索では何も出さない
+// 2〜4文字 → 結果があれば出す、なければ非表示
+// 5文字以上 → 結果がなければ「検索結果が見当たりません」と表示
+// 検索ボタンを押した場合 → 必ず「検索結果が見当たりませんでした」を表示
+const searchResultsContainer = document.getElementById(
+  "keywords-search-results"
+);
+
+async function performSearch(keywordsQuery, isManualSearch) {
+  searchResultsContainer.innerHTML = "";
+  searchResultsContainer.style.display = "inline-block";
+  const resultsUl = document.createElement("ul");
+  resultsUl.id = "results-list";
+
+  // クリアボタン表示/非表示
+  const clearBtn = document.getElementById("clear-button");
+  if (keywordsQuery.length === 0) {
+    clearBtn.style.display = "none";
+  } else if (keywordsQuery.length >= 1) {
+    clearBtn.style.display = "inline-block";
+  }
+
+  // クリアボタン機能 (クリックで入力欄と結果をクリア)
+  clearBtn.addEventListener("click", function () {
+    document.getElementById("live-search").value = "";
+    searchResultsContainer.style.display = "none";
+    searchResultsContainer.innerHTML = "";
+    clearBtn.style.display = "none";
+  });
+
+  // 検索文字が2文字未満なら検索結果を消す
+  if (!keywordsQuery || (keywordsQuery.length < 2 && !isManualSearch)) {
+    searchResultsContainer.style.display = "none";
+    searchResultsContainer.innerHTML = "";
+    return [];
+  }
+
+  // ローディング表示
+
+  //   resultsUl.innerHTML = "<li>ローディング中...</li>";
+
+  // 検索処理///
+  // 1. キーワード検索
+  const keywordRes = await fetch(
+    `/wp-json/wp/v2/posts?search=${encodeURIComponent(
+      keywordsQuery
+    )}&per_page=5&_embed`
+  );
+  const keywordPosts = await keywordRes.json();
+
+  // 2. カテゴリー名からカテゴリーIDを取得
+  const catRes = await fetch(
+    `/wp-json/wp/v2/categories?search=${encodeURIComponent(keywordsQuery)}`
+  );
+  const categoryRes = await catRes.json();
+
+  let categoryPosts = [];
+  if (categoryRes.length > 0) {
+    const categoryId = categoryRes[0].id;
+    const categoryPostRes = await fetch(
+      `/wp-json/wp/v2/posts?categories=${categoryId}&per_page=5&_embed`
+    );
+    categoryPosts = await categoryPostRes.json();
+  }
+
+  // 3. タグ検索(タグ名からタグIDを取得)
+  const tagRes = await fetch(
+    `/wp-json/wp/v2/tags?search=${encodeURIComponent(keywordsQuery)}`
+  );
+  const tags = await tagRes.json();
+  let tagPosts = [];
+
+  if (tags.length > 0) {
+    const tagId = tags[0].id;
+    const tagPostRes = await fetch(
+      `/wp-json/wp/v2/posts?tags=${tagId}&per_page=5&_embed`
+    );
+    tagPosts = await tagPostRes.json();
+  }
+  // 結果表示処理///
+  // 両方の結果をマージ & 重複除去
+  const allPosts = [...keywordPosts, ...categoryPosts, ...tagPosts];
+
+  const filteredPosts = Array.from(
+    new Map(allPosts.map((post) => [post.id, post])).values()
+  );
+
+  // まず既存のULをクリア
+  resultsUl.innerHTML = "";
+
+  // 投稿がなければ非表示にして終了
+  if (filteredPosts.length === 0) {
+    if (isManualSearch) {
+      resultsUl.innerHTML = "<li>検索結果が見当たりませんでした</li>";
+      //   searchResultsContainer.appendChild(resultsUl);
+    } else if (keywordsQuery.length >= 5) {
+      resultsUl.innerHTML = "<li>検索結果が見当たりません</li>";
+      //   searchResultsContainer.appendChild(resultsUl);
+    } else {
+      // それ以外（まだ文字数少ない）→ 何も出さない
+      searchResultsContainer.style.display = "none";
+      return;
+    }
+  } else {
+    // searchResultsContainer.style.display = "inline-block";
+    filteredPosts.forEach((post) => {
+      const listItem = document.createElement("li");
+      const postLink = document.createElement("a");
+      const postTitle = document.createElement("h3");
+      const postImg = document.createElement("img");
+      const postText = document.createElement("p");
+
+      postTitle.classList.add("result-title");
+      postText.classList.add("result-text");
+      postImg.classList.add("result-img");
+
+      postLink.href = post.link;
+      postTitle.textContent = post.title.rendered;
+
+      // アイキャッチ画像
+      if (post._embedded && post._embedded["wp:featuredmedia"]) {
+        postImg.src = post._embedded["wp:featuredmedia"][0].source_url;
+      } else {
+        postImg.src = "https://via.placeholder.com/80";
+      }
+      postImg.alt = post.title.rendered;
+      postLink.appendChild(postImg);
+
+      // 抜粋50文字
+      let excerpt = post.excerpt.rendered.replace(/(<([^>]+)>)/gi, "");
+      postText.textContent =
+        excerpt.length > 50 ? excerpt.substring(0, 50) + "…" : excerpt;
+
+      postLink.appendChild(postTitle);
+      postLink.appendChild(postText);
+
+      listItem.appendChild(postLink);
+      resultsUl.appendChild(listItem);
+    });
+  }
+  searchResultsContainer.appendChild(resultsUl);
+  //   return filteredPosts;
+}
+
+// 「入力時」の予測表示
+document
+  .getElementById("live-search")
+  .addEventListener("input", async function () {
+    const keywordsQuery = this.value;
+    await performSearch(keywordsQuery, (isManualSearch = false)); // 入力されている文字列で検索
+  });
+
+// 「検索ボタン押下 or Enter押下時」の検索実行
+document
+  .querySelector(".search_container")
+  .addEventListener("submit", async function (e) {
+    e.preventDefault();
+    const keywordsQuery = document.getElementById("live-search").value;
+    await performSearch(keywordsQuery, true);
+  });

--- a/js/search.js
+++ b/js/search.js
@@ -150,11 +150,22 @@ document
     await performSearch(keywordsQuery, (isManualSearch = false)); // 入力されている文字列で検索
   });
 
-// 「検索ボタン押下 or Enter押下時」の検索実行
+document
+  .getElementById("header-keywords-submit")
+  .addEventListener("click", function (e) {
+    e.preventDefault();
+    const query = document.getElementById("live-search").value;
+    if (query.trim() === "") return;
+    // 固定ページにクエリを付けて遷移
+    window.location.href = `/search-result?query=${encodeURIComponent(query)}`;
+  });
+
+// Enter押下時
 document
   .querySelector(".search_container")
-  .addEventListener("submit", async function (e) {
+  .addEventListener("submit", function (e) {
     e.preventDefault();
-    const keywordsQuery = document.getElementById("live-search").value;
-    await performSearch(keywordsQuery, true);
+    const query = document.getElementById("live-search").value;
+    if (query.trim() === "") return;
+    window.location.href = `/search-result?query=${encodeURIComponent(query)}`;
   });

--- a/page-search-result.php
+++ b/page-search-result.php
@@ -1,0 +1,146 @@
+<?php
+get_header(); 
+get_sidebar(); 
+?>
+
+<main class="page-content">
+
+
+  <div class="wrapper info-top">
+    <p class="info-details">
+    検索結果<br />
+    検索結果<br />
+    検索結果
+    </p>
+    <p class="info-underline"></p>
+  </div>
+
+  <div class="wrapper">
+    <ul class="cards-list">
+
+    <?php
+      $query = isset($_GET['query']) ? sanitize_text_field($_GET['query']) : '';
+      
+      if ( !empty($query) ) {
+
+        $posts = [];
+
+        // 投稿タイトル/本文検索
+        $post_args = [
+            'post_type' => 'post',
+            's' => $query,
+            'posts_per_page' => 10,
+        ];
+        $post_query = new WP_Query($post_args);
+        if ( $post_query->have_posts() ) {
+            $posts = array_merge($posts, $post_query->posts);
+        }
+        wp_reset_postdata();
+
+        // カテゴリー名検索
+        $cat = get_term_by('name', $query, 'category');
+        if ($cat) {
+            $cat_posts = get_posts([
+                'post_type' => 'post',
+                'posts_per_page' => 10,
+                'tax_query' => [
+                    [
+                        'taxonomy' => 'category',
+                        'field' => 'term_id',
+                        'terms' => $cat->term_id,
+                    ],
+                ],
+            ]);
+            $posts = array_merge($posts, $cat_posts);
+        }
+
+        // タグ名検索
+        $tag = get_term_by('name', $query, 'post_tag');
+        if ($tag) {
+            $tag_posts = get_posts([
+                'post_type' => 'post',
+                'posts_per_page' => 10,
+                'tax_query' => [
+                    [
+                        'taxonomy' => 'post_tag',
+                        'field' => 'term_id',
+                        'terms' => $tag->term_id,
+                    ],
+                ],
+            ]);
+            $posts = array_merge($posts, $tag_posts);
+        }
+
+        // 重複削除
+        $posts = array_unique($posts, SORT_REGULAR);
+
+        if (!empty($posts)) {
+            foreach ($posts as $post) {
+                setup_postdata($post);
+                ?>
+            <li class="card-container">
+                <div class="card">  
+                    <a href="<?php echo esc_url(home_url('/details.html'));?>">
+                        <?php if ( has_post_thumbnail() ) : ?>
+                        <?php the_post_thumbnail( 'medium', array( 'class' => 'card-image' ) ); ?>
+                        <?php endif; ?>
+                    </a>
+
+                    <div class="card-body">
+                        <div class="card-top">
+                        <a href="<?php the_permalink(); ?>">
+                            <h3 class="card-title"><?php the_title(); ?></h3>
+                        </a>
+                        <ul class="card-tags">
+                            <?php
+                            $categories = get_the_category();
+                            if ( !empty( $categories ) ) {
+                                foreach ( $categories as $cat ) {
+                                echo '<li><p class="card-tag-list">' . esc_html( $cat->name ) . '</p></li>';
+                                }
+                            }
+                            ?>
+                        </ul>
+                        </div>
+                        <p class="card-text"><?php echo get_the_excerpt(); ?></p>
+
+                        <div class="card-bottom">
+                            <p class="post-date"><?php echo get_the_date('Y/m/d'); ?></p>
+                            <div class="card-icons">
+                                <!-- いいねボタン -->
+                                    <?php if ( function_exists( 'wp_ulike' ) ) { wp_ulike(); } ?>
+                                <!-- Clickボタン -->
+                                <div class=post-view>
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" width="32" height="32" color="#4a2b00">
+                                        <defs><style>.cls-637b8170f95e86b59c57a03a-1{fill:none;stroke:currentColor;stroke-miterlimit:10;}</style></defs>
+                                        <g id="eye"><path class="cls-637b8170f95e86b59c57a03a-1" d="M22.5,12A12.24,12.24,0,0,1,12,17.73,12.24,12.24,0,0,1,1.5,12,12.24,12.24,0,0,1,12,6.27,12.24,12.24,0,0,1,22.5,12Z">
+                                        </path><circle class="cls-637b8170f95e86b59c57a03a-1" cx="12" cy="12" r="5.73"></circle>
+                                        <circle class="cls-637b8170f95e86b59c57a03a-1" cx="12" cy="12" r="1.91">
+                                        </circle></g>
+                                    </svg>
+                                    <a href="<?php the_permalink(); ?>" class="view"><?php the_views(false); ?></a> 
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </li>
+        <?php
+}
+
+           
+            wp_reset_postdata();
+        } else {
+            echo '<p>検索結果が見当たりませんでした</p>';
+        }
+
+      } else {
+        echo '<p>検索ワードを入力してください</p>';
+      }
+    ?>
+    </ul>
+
+  </div>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
search&filter プラグインのキーワード検索追加
（無料版のSearch & Filterでは、カテゴリーやタグ、投稿タイトルを同時に検索することができなかったので、WordPressのデータをREST API経由で取得し、Search.jsを使って一度に検索できるようにしています。）

eventの部分をヘッダーのEventボタンから繋ぎました。（WPコントロールから固定ページにeventを追加、スラッグを”event"に設定）functions.phpにイベントの固定ページの時のみEVENT.cssが反応するように追加



