### PR TITLE
search & filter plugin working 100% with live search

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -340,7 +340,7 @@ Card一覧
   height: 400px;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, 0.3);
-  border-radius: 0.5rem;
+  border-radius: 0.3rem;
   padding: 1rem 5%;
   cursor: pointer;
   box-shadow: 0 5px 8px rgba(0, 0, 0, 0.3);
@@ -362,8 +362,6 @@ Card一覧
 .card-image {
   width: 100%;
   height: 200px;
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
 }
 
 .card-body {
@@ -728,6 +726,7 @@ footer {
 }
 #keywords-search-results #results-list {
   padding: 5px 10px;
+  min-width: 350px;
   min-height: 200px;
 }
 #keywords-search-results #results-list li {

--- a/footer.php
+++ b/footer.php
@@ -3,11 +3,8 @@
       <p class="copyright">&copy; PortNavi</p>
     </footer>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-
-    <script src="<?php echo get_template_directory_uri(); ?>/js/search.js"></script>
-    <script src="<?php echo get_template_directory_uri(); ?>/js/main.js"></script>
 
     <?php wp_footer();?>
   </body>
 </html>
+

--- a/front-page.php
+++ b/front-page.php
@@ -55,7 +55,7 @@
                         <?php if ( function_exists( 'wp_ulike' ) ) { wp_ulike(); } ?>
                     <!-- Clickボタン -->
                     <div class=post-view>
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" width="32" height="32" color="#4a2b00">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1" width="32" height="32" color="#4a2b00">
                             <defs><style>.cls-637b8170f95e86b59c57a03a-1{fill:none;stroke:currentColor;stroke-miterlimit:10;}</style></defs>
                             <g id="eye"><path class="cls-637b8170f95e86b59c57a03a-1" d="M22.5,12A12.24,12.24,0,0,1,12,17.73,12.24,12.24,0,0,1,1.5,12,12.24,12.24,0,0,1,12,6.27,12.24,12.24,0,0,1,22.5,12Z">
                             </path><circle class="cls-637b8170f95e86b59c57a03a-1" cx="12" cy="12" r="5.73"></circle>

--- a/header.php
+++ b/header.php
@@ -33,11 +33,6 @@
         </nav>
 
 
-        <!-- 検索フォーム1 search&filter　これは参考後で消す-->
-        <!-- <?php echo do_shortcode('[searchwp_form id="1"]'); ?> -->
-        <!-- <?php echo do_shortcode('[searchandfilter  fields="search,category,post_tag" headings=",Categories,Tags" types="search" post_types="post"]'); ?> -->
-         
-        
         <!-- 検索フォーム 本番用-->
         <form method="get"action="<?php echo esc_url( home_url( '/' ) ); ?>" class="search_container">
         <input type="text" id="live-search" size="25" name="s" placeholder="キーワード検索" value=""/>
@@ -49,7 +44,7 @@
       </div>
 
 
-
+<!-- ライブ検索用のDIV -->
       <div id="keywords-search-results">
       </div>
 

--- a/js/search.js
+++ b/js/search.js
@@ -1,226 +1,124 @@
-// ///////////////////////////////////////////////////////////////////////////////////////////
-// 2文字未満 → 予測検索では何も出さない
-// 2〜4文字 → 結果があれば出す、なければ非表示
-// 5文字以上 → 結果がなければ「検索結果が見当たりません」と表示
-// 検索ボタンを押した場合 → 必ず「検索結果が見当たりませんでした」を表示
-let isLoading = false;
+// // 2文字未満 → 予測検索では何も出さない
+// // 2〜4文字 → 結果があれば出す、なければ非表示
+// // 5文字以上 → 結果がなければ「検索結果が見当たりません」と表示
+// // 検索ボタンを押した場合 → 必ず「検索結果が見当たりませんでした」を表示
+// let isLoading = false;
+
+// Search & filter プラグインの Ajax ライブ検索を利用して、カテゴリー・タグも検索対象にする（オリジナルのtaxonomyも対象に）
 const searchResultsContainer = document.getElementById(
   "keywords-search-results"
 );
 const clearBtn = document.getElementById("clear-button");
-const keywordsInput = document.getElementById("live-search");
+const searchInput = document.getElementById("live-search");
 
-// // // クリアボタン機能 (クリックで入力欄と結果をクリア)
-clearBtn.addEventListener("click", function () {
-  keywordsInput.value = "";
-  searchResultsContainer.style.display = "none";
-  searchResultsContainer.innerHTML = "";
-  clearBtn.style.display = "none";
-  isLoading = false;
-});
-
-// fetchして検索結果を取得し、表示する関数
-// 1. キーワード検索
-async function keywordsQueryCheck(keywordsQuery) {
-  const res = await fetch(
-    `/wp-json/wp/v2/posts?search=${encodeURIComponent(
-      keywordsQuery
-    )}&per_page=5&_embed`
-  );
-  return res.json();
-}
-
-// 2. カテゴリー名からカテゴリーIDを取得
-async function categoryCheck(keywordsQuery) {
-  const catRes = await fetch(
-    `/wp-json/wp/v2/categories?search=${encodeURIComponent(keywordsQuery)}`
-  );
-  const categories = await catRes.json();
-  if (categories.length === 0) return [];
-  const catId = categories[0].id;
-  const postRes = await fetch(
-    `/wp-json/wp/v2/posts?categories=${catId}&per_page=5&_embed`
-  );
-  return postRes.json();
-}
-
-// 3. タグ検索(タグ名からタグIDを取得)
-async function tagCheck(keywordsQuery) {
-  const tagRes = await fetch(
-    `/wp-json/wp/v2/tags?search=${encodeURIComponent(keywordsQuery)}`
-  );
-  const tags = await tagRes.json();
-  if (tags.length === 0) return [];
-  const tagId = tags[0].id;
-  const postRes = await fetch(
-    `/wp-json/wp/v2/posts?tags=${tagId}&per_page=5&_embed`
-  );
-  return postRes.json();
-}
-
-async function performSearch(keywordsQuery, isManualSearch = false) {
-  // 検索文字が2文字未満ならキャンセル
-  if (!keywordsQuery || (keywordsQuery.length < 2 && !isManualSearch)) {
-    clearBtn.style.display = "none";
-    searchResultsContainer.style.display = "none";
-    searchResultsContainer.innerHTML = "";
-    return;
-  }
-
-  const resultsUl = document.createElement("ul");
-  resultsUl.id = "results-list";
-  resultsUl.innerHTML = `
-        <div style="text-align:center; padding:100px; width:350px;">
-   <img src="/wp-content/themes/portnavi/img/icons/loading.gif" alt="Loading..." style="text-align:center; padding:10px; width:50px;"/>
-</div>
-  `;
-  searchResultsContainer.style.display = "block";
-  searchResultsContainer.innerHTML = "";
-  searchResultsContainer.appendChild(resultsUl);
-  clearBtn.style.display = "inline-block";
-  isLoading = true;
-
-  // // // クリアボタン表示/非表示
-  if (keywordsInput.value.length === 0) {
-    clearBtn.style.display = "none";
-    return;
-  } else if (keywordsInput.value.length >= 1) {
+// クリアボタン表示/非表示
+function toggleClearButton(value) {
+  if (value.length > 0) {
     clearBtn.style.display = "inline-block";
+  } else {
+    clearBtn.style.display = "none";
   }
-  // 検索結果を取得
-  // searchResultsContainer.innerHTML = "";
-  // searchResultsContainer.style.display = "inline-block";
-
-  // タイムアウト制御用
-  let timeoutId;
-  let timeoutTriggered = false;
-
-  try {
-    // 2〜4文字 → タイムアウト設定
-    if (keywordsQuery.length >= 2 && keywordsQuery.length <= 4) {
-      timeoutId = setTimeout(() => {
-        timeoutTriggered = true;
-        resultsUl.innerHTML = `
-          <li style="text-align:center; padding:100px; width:350px;">
-            検索結果が見当たりませんでした
-          </li>
-        `;
-        isLoading = false;
-      }, 5000);
-    }
-
-    // 並列で全部検索
-    const [keywordPosts, categoryPosts, tagPosts] = await Promise.all([
-      keywordsQueryCheck(keywordsQuery),
-      categoryCheck(keywordsQuery),
-      tagCheck(keywordsQuery),
-    ]);
-
-    if (timeoutTriggered) return; // すでにタイムアウト表示してたら処理しない
-    if (timeoutId) clearTimeout(timeoutId);
-    console.log("これで確認", keywordPosts, categoryPosts, tagPosts);
-
-    // 3. 取得結果をまとめて重複除去
-    const allPosts = [...keywordPosts, ...categoryPosts, ...tagPosts];
-
-    const filteredPosts = Array.from(
-      new Map(allPosts.map((post) => [post.id, post])).values()
-    );
-    console.log("重複除去後", filteredPosts);
-
-    // ローディングを消して結果表示
-    searchResultsContainer.innerHTML = "";
-
-    if (filteredPosts.length === 0) {
-      if (isManualSearch || keywordsQuery.length >= 5) {
-        resultsUl.innerHTML = `
-        <li style="text-align:center; padding:100px; width:350px;">検索結果が見当たりませんでした</li>
-      `;
-      } else {
-        isLoading = true;
-        searchResultsContainer.style.display = "block";
-        resultsUl.innerHTML = `
-      <div style="text-align:center; padding:100px; width:350px;">
-   <img src="/wp-content/themes/portnavi/img/icons/loading.gif" alt="Loading..." style="text-align:center; padding:10px; width:50px;"/>
-</div>
-        `;
-        setTimeout(() => {
-          timeoutTriggered = true;
-          resultsUl.innerHTML = `
-          <li style="text-align:center; padding:100px; width:350px;">検索結果が見当たりませんでした</li>
-        `;
-          isLoading = false;
-        }, 5000); // 5秒後
-      }
-    } else {
-      searchResultsContainer.innerHTML = "";
-      // searchResultsContainer.style.display = "inline-block";
-      filteredPosts.forEach((post) => {
-        const listItem = document.createElement("li");
-        const postLink = document.createElement("a");
-        const postTitle = document.createElement("h3");
-        const postImg = document.createElement("img");
-        const postText = document.createElement("p");
-
-        postTitle.classList.add("result-title");
-        postText.classList.add("result-text");
-        postImg.classList.add("result-img");
-
-        postLink.href = post.link;
-        postTitle.textContent = post.title.rendered;
-
-        // アイキャッチ画像
-        if (post._embedded && post._embedded["wp:featuredmedia"]) {
-          postImg.src = post._embedded["wp:featuredmedia"][0].source_url;
-        } else {
-          postImg.src = "https://via.placeholder.com/80";
-        }
-        postImg.alt = post.title.rendered;
-        postLink.appendChild(postImg);
-
-        // 抜粋50文字
-        let excerpt = post.excerpt.rendered.replace(/(<([^>]+)>)/gi, "");
-        postText.textContent =
-          excerpt.length > 50 ? excerpt.substring(0, 50) + "…" : excerpt;
-
-        postLink.appendChild(postTitle);
-        postLink.appendChild(postText);
-
-        listItem.appendChild(postLink);
-        resultsUl.appendChild(listItem);
-      });
-    }
-    searchResultsContainer.appendChild(resultsUl);
-  } catch (error) {
-    console.error("検索中にエラーが発生しました:", error);
-    searchResultsContainer.innerHTML = "<li>エラーが発生しました</li>";
-  } finally {
-    isLoading = false;
-  }
-  return;
 }
 
-// 入力時のライブ検索
-keywordsInput.addEventListener("input", async function () {
-  await performSearch(this.value, false);
+// クリアボタン機能 (クリックで入力欄と結果をクリア)
+clearBtn.addEventListener("click", function () {
+  searchInput.value = "";
+  searchResultsContainer.innerHTML = "";
+  toggleClearButton("");
+  // isLoading = false;
 });
 
-// 検索ボタン押下時
-document
-  .getElementById("header-keywords-submit")
-  .addEventListener("click", function (e) {
-    e.preventDefault();
-    const query = keywordsInput.value.trim();
-    if (!query) return;
-    window.location.href = `/?s=${encodeURIComponent(query)}`;
-  });
+// キーワード入力時のライブ検索
+document.addEventListener("DOMContentLoaded", function () {
+  // 初期表示時のクリアボタン表示/非表示
+  toggleClearButton(searchInput.value);
 
-// Enter押下時
-document
-  .querySelector(".search_container")
-  .addEventListener("submit", function (e) {
-    e.preventDefault();
-    const query = keywordsInput.value.trim();
-    if (!query) return;
-    window.location.href = `/?s=${encodeURIComponent(query)}`;
+  // ライブ検索
+  searchInput.addEventListener("input", async function () {
+    const keyword = this.value.trim();
+
+    toggleClearButton(keyword);
+
+    // ２文字未満ならライブ検索結果は何も表示しない
+    if (keyword.length < 2) {
+      searchResultsContainer.innerHTML = "";
+      return;
+    }
+
+    // AJAXリクエスト用のFormDataを作成
+    const formData = new FormData();
+    formData.append("action", "live_tax_search");
+    formData.append("keyword", keyword);
+
+    //AJAXリクエストを送信
+    try {
+      const response = await fetch(live_tax_vars.ajax_url, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      // 前回の結果をクリア
+      searchResultsContainer.innerHTML = "";
+
+      // ライブ検索結果の表示用ULリストを作成
+      const resultsUl = document.createElement("ul");
+      resultsUl.id = "results-list";
+
+      if (data.length) {
+        data.forEach((item) => {
+          if (!item.title) return;
+
+          const listItem = document.createElement("li");
+          listItem.classList.add("search-result-item");
+
+          const postLink = document.createElement("a");
+          postLink.href = item.link;
+
+          const postTitle = document.createElement("h3");
+          postTitle.classList.add("result-title");
+          postTitle.textContent = item.title;
+
+          const postText = document.createElement("p");
+          postText.classList.add("result-text");
+          if (item.excerpt) {
+            let excerpt = item.excerpt.replace(/(<([^>]+)>)/gi, "");
+            postText.textContent =
+              excerpt.length > 50 ? excerpt.substring(0, 50) + "…" : excerpt;
+          }
+
+          if (item.thumbnail) {
+            const postImg = document.createElement("img");
+            postImg.classList.add("result-img");
+            postImg.src = item.thumbnail;
+            postImg.alt = item.title;
+            postLink.appendChild(postImg);
+          }
+
+          postLink.appendChild(postTitle);
+          postLink.appendChild(postText);
+          listItem.appendChild(postLink);
+          resultsUl.appendChild(listItem);
+        });
+
+        searchResultsContainer.appendChild(resultsUl);
+        searchResultsContainer.style.display = "block";
+      } else {
+        const listItem = document.createElement("li");
+        listItem.classList.add("search-result-item");
+        listItem.innerHTML = `<h3 class="result-title">該当なし</h3>`;
+        resultsUl.appendChild(listItem);
+        searchResultsContainer.appendChild(resultsUl);
+        searchResultsContainer.style.display = "block";
+      }
+    } catch (error) {
+      console.error("Error fetching search results:", error);
+      searchResultsContainer.innerHTML = `<li class="search-result-item">検索中にエラーが発生しました</li>`;
+    }
   });
+});

--- a/search.php
+++ b/search.php
@@ -25,12 +25,34 @@ get_sidebar();
 
     
     <?php
-      $query = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+
+$query = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
+
       
       
       if ( !empty($query) ) {
-
         $posts = [];
+
+// カスタムタクソノミー検索
+$custom_taxonomies = ['site_type','design_type','color','tech_stack'];
+foreach ( $custom_taxonomies as $tax ) {
+    $term = get_term_by('name', $query, $tax);
+    if ( $term ) {
+        $tax_posts = get_posts([
+            'post_type' => 'post',
+            'posts_per_page' => 10,
+            'tax_query' => [
+                [
+                    'taxonomy' => $tax,
+                    'field'    => 'term_id',
+                    'terms'    => $term->term_id,
+                ],
+            ],
+        ]);
+        $posts = array_merge($posts, $tax_posts);
+    }
+}
+
 
         // 投稿タイトル/本文検索
         $post_args = [


### PR DESCRIPTION
Search &filterプラグインを使用して以下を可能に修正しました。
ー投稿タイトル、投稿文の内容（これは既存で機能ついている）
ー追加でWP管理画面城から作成したカテゴリーとタグ
ーオリジナルのタクソノミーのカテゴリーとタグも検索に反映できるよう追加
ーライブ検索表示も追加することができました。


